### PR TITLE
Additional parenthesis added

### DIFF
--- a/sample_project/Source/sample_project/Routing/RouteManager.cpp
+++ b/sample_project/Source/sample_project/Routing/RouteManager.cpp
@@ -254,14 +254,14 @@ void ARouteManager::ProcessQueryResponse(FHttpRequestPtr Request, FHttpResponseP
 		Breadcrumbs.Empty();
 
 		// Parse the query response
-		if (RoutesField = JsonObj->TryGetField(TEXT("routes"))) {
+		if ((RoutesField = JsonObj->TryGetField(TEXT("routes")))) {
 			JsonObj = RoutesField->AsObject();
 			if (JsonObj->TryGetArrayField(TEXT("features"), FeaturesField)) {
 
 				for (auto feature : *FeaturesField) {
 					JsonObj = feature->AsObject();
 					AttributesField = JsonObj->TryGetField(TEXT("attributes")); // checked later
-					if (GeometryField = JsonObj->TryGetField(TEXT("geometry"))) {
+					if ((GeometryField = JsonObj->TryGetField(TEXT("geometry")))) {
 						JsonObj = GeometryField->AsObject();
 						if (JsonObj->TryGetArrayField(TEXT("paths"), PathsField)) {
 							for (auto path : *PathsField) {


### PR DESCRIPTION
To fix the issues compiling the project.

**Sample**

Adds parenthesis to the Routing sample's RputeManager.cpp file.

**Summary**
The project was unable to be compiled and opened on MacOS, so I added a few parenthesis and it's all happy now. 

![image](https://user-images.githubusercontent.com/42052635/183473521-14557008-c8e5-4dff-a8a7-8674ec8f9c3b.png)
![image](https://user-images.githubusercontent.com/42052635/183473605-a57578bc-29d1-4e89-83c0-e07fc43acbfa.png)

This issue could be related to this user issue: https://community.esri.com/t5/arcgis-maps-sdk-for-unreal-engine-questions/how-to-re-compile-samples-project-through-visual/m-p/1200220#M20
**Tests**

Tested on Windows and MacOS

**ArcGIS Maps SDK Version**

Latest daily build, 3595
