### PR TITLE
Fix API Key map component calls

### DIFF
--- a/sample_project/Source/sample_project/Geocoding/Geocoder.cpp
+++ b/sample_project/Source/sample_project/Geocoding/Geocoder.cpp
@@ -93,7 +93,7 @@ void AGeocoder::SendAddressQuery(FString Address)
 	}
 	FString Url = "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates";
 	UArcGISMapComponent* MapComponent = UArcGISMapComponent::GetMapComponent(this);
-	FString APIToken = MapComponent ? MapComponent->GetAPIkey() : "";
+	FString APIToken = MapComponent ? MapComponent->GetAPIKey() : "";
 	FString Query;
 
 	// Set up the query 
@@ -180,7 +180,7 @@ void AGeocoder::SendLocationQuery(UArcGISPoint* InPoint)
 	}
 	FString Url = "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode";
 	UArcGISMapComponent* MapComponent = UArcGISMapComponent::GetMapComponent(this);
-	FString APIToken = MapComponent ? MapComponent->GetAPIkey() : "";
+	FString APIToken = MapComponent ? MapComponent->GetAPIKey() : "";
 	FString Query;
 	UArcGISPoint* Point(InPoint);
 

--- a/sample_project/Source/sample_project/Routing/RouteManager.cpp
+++ b/sample_project/Source/sample_project/Routing/RouteManager.cpp
@@ -207,7 +207,7 @@ void ARouteManager::PostRoutingRequest()
 	MapComponent = UArcGISMapComponent::GetMapComponent(this);
 
 	// Read the API key from the map component
-	FString APIToken = MapComponent ? MapComponent->GetAPIkey() : "";
+	FString APIToken = MapComponent ? MapComponent->GetAPIKey() : "";
 
 	// Set the request body and sent it
 	RequestBody = TEXT("f=json&returnRoutes=true&token=") + APIToken + TEXT("&stops=") + StopCoordinates;


### PR DESCRIPTION
**Sample**

This updates Geocoder and RouteManager calls to updated `GetAPIKey()`. The PR should be merged after 1.1 release

**ArcGIS Maps SDK Version**

SDK 1.1