### PR TITLE
Fixed measure visuals and repitition bug

### DIFF
--- a/sample_project/Source/sample_project/Measure/Measure.h
+++ b/sample_project/Source/sample_project/Measure/Measure.h
@@ -80,6 +80,7 @@ private:
 	UFunction* WidgetFunction;
 	double SegmentDistance;
 	FActorSpawnParameters SpawnParam = FActorSpawnParameters();
+	float MarkerHeight = 7000.f;
 
 	void AddStop();
 	void Interpolate(AActor* start, AActor* end);

--- a/sample_project/Source/sample_project/Routing/Breadcrumb.h
+++ b/sample_project/Source/sample_project/Routing/Breadcrumb.h
@@ -38,7 +38,7 @@ public:
 	UStaticMeshComponent* MeshComponent;
 
 	UPROPERTY(VisibleAnywhere)
-	FVector3d MeshScale = FVector3d(7.);
+	FVector3d MeshScale = FVector3d(15.);
 
 protected:
 	// Called when the game starts or when spawned


### PR DESCRIPTION
**Sample**

Measure sample spawns visual line between markers at the head of the markers now instead of the base

**Summary**

Added height of marker variable
Used it to move the line and interpolation blocks upward
Fixed issue where line would be spawned in multiple times because of repeated elements in the list
Made interpolation boxes bigger so they are easier to see

**Tests**

Tested with antiquated laptop that would crash constantly

**ArcGIS Maps SDK Version**

1.2
