### PR TITLE
Retarget Widget to correct file path

### DIFF
--- a/sample_project/Source/sample_project/3DAttribute/APIMapCreator.cpp
+++ b/sample_project/Source/sample_project/3DAttribute/APIMapCreator.cpp
@@ -39,7 +39,7 @@ AAPIMapCreator::AAPIMapCreator()
 
 	ViewStateLogging = CreateDefaultSubobject<UViewStateLoggingComponent>(TEXT("ArcGISViewStateLoggingComponent"));
 
-	static ConstructorHelpers::FObjectFinder<UClass> WidgetAsset(TEXT("/Game/SampleViewer/Samples/3DAttribute/UserInterface/WBP_3DAttribute.WBP_3DAttribute_c"));
+	static ConstructorHelpers::FObjectFinder<UClass> WidgetAsset(TEXT("/Game/SampleViewer/Samples/MaterialByAttribute/UserInterface/WBP_3DAttribute.WBP_3DAttribute_c"));
 	if (WidgetAsset.Succeeded())
 	{
 		UIWidgetClass = WidgetAsset.Object;


### PR DESCRIPTION
**Sample**

Fix Material By Attributes

**Summary**

The widget was using the old location and therefore did not load. Corrected the file path and it now loads.

**Tests**

Windows

**ArcGIS Maps SDK Version**

UE 5.0 w/Maps SDK 1.3
