### PR TITLE
Unifying readme title formats

### DIFF
--- a/sample_project/Content/SampleViewer/Samples/RealTime_Weather/readme.md
+++ b/sample_project/Content/SampleViewer/Samples/RealTime_Weather/readme.md
@@ -1,4 +1,4 @@
-# Query Current Weather Conditions Across the U.S.A
+# Query current weather conditions across the U.S.A
 
 Query Weather Data from the Weather Stations feature layer provided in order to display weather conditions on the map.
 
@@ -19,12 +19,12 @@ Query Weather Data from the Weather Stations feature layer provided in order to 
 
 ## How it works
 
-1. Create a new C++ class and make a http request to [query a feature layer](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-.htm). 
+1. Create a new C++ class and make an HTTP request to [query a feature layer](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-.htm). 
 2. Create a new Blueprint Actor class
    - Create the event to place the data returned from the Weather Query.
    - Create a function to spawn the weather actor according to the data received in the query.
    - Attach the [**ArcGIS Location Component**](https://developers.arcgis.com/unreal-engine/maps/location-component/) to the weather actor blueprint class.
-   - Add aditional functionality to spawn/show different **Niagra Particle Effects** based on the current weather data returned from the **Weather Query**.
+   - Add additional functionality to spawn/show different **Niagra Particle Effects** based on the current weather data returned from the **Weather Query**.
 3. Create a widget for the viewport so users can select a city from the list fed from the feature service.
 
 Note: You can use `UE_LOG` to print log messages in the **Output Log** window and see if you are gathering the data properly from the feature service.

--- a/sample_project/Content/SampleViewer/Samples/ThirdPersonCharacter/readme.md
+++ b/sample_project/Content/SampleViewer/Samples/ThirdPersonCharacter/readme.md
@@ -1,6 +1,6 @@
-# Explore with Third Person Character
+# Explore with a third-person character
 
-Allows users to explore a city/map from the perspective of a Third Person Character.
+Allows users to explore a city/map from the perspective of a third-person character.
 
 ![Image of Third Person Controller](ThirdPersonController.png)
 
@@ -8,7 +8,7 @@ Allows users to explore a city/map from the perspective of a Third Person Charac
 
 1. Open the **ThirdPerson** level.
 2. Click on the **ArcGISMapActor** in the Outliner panel.
-3. Set your API key under th **Authentication** section in the Details panel.
+3. Set your API key under the **Authentication** section in the Details panel.
 4. Click play and move the character by using the WASD keys and the right mouse button. Jump with the space key.
 
 Note: The terrain needs to be loaded before the Third Person Character falls on the ground. Adjust the `Z` Location value of the **BP_ThirdPersonCharacter** in order to gain more time for the terrain to be loaded if it's necessary.
@@ -20,7 +20,7 @@ Note: The terrain needs to be loaded before the Third Person Character falls on 
 2. Create a Third Person Character with its control and attach the [**ArcGIS Camera Component**](https://developers.arcgis.com/unreal-engine/maps/camera/#arcgis-camera-component) to the Character Mesh. 
 3. Add the Third Person Character to the level.
    - Mesh colliders need to be enabled in the **ArcGIS Map Component**.
-   - If you want to place the character on a specific location, attach the [**ArcGIS Location Component**](https://developers.arcgis.com/unreal-engine/maps/location-component/) to specify it.
+   - If you want to place the character in a specific location, attach the [**ArcGIS Location Component**](https://developers.arcgis.com/unreal-engine/maps/location-component/) to specify it.
    - Adjust the `Z` Location value of the character to have enough time to load the terrain.
 
 ## About the data

--- a/xr_sample_project/Content/Samples/VRSample/readme.md
+++ b/xr_sample_project/Content/Samples/VRSample/readme.md
@@ -1,6 +1,6 @@
-# Explore with Virtual Reality
+# Explore the world in virtual reality
 
-Allows users to explore a city/map from the first person perspective using Virtual Reality.
+Allows users to explore a city/map from the first-person perspective using Virtual Reality.
 
 ![Image of Virtual Reality Sample](VRSample.png)
 
@@ -9,7 +9,7 @@ Allows users to explore a city/map from the first person perspective using Virtu
 1. Prior to opening the project, ensure your VR headset is connected and any required software is running (SteamVR, Oculus, Vive Streaming Hub).
 2. Open the **VRSample_lvl** level.
 3. Click on the **ArcGISMapActor** in the Outliner panel.
-4. Set your API key under th **Authentication** section in the Details panel.
+4. Set your API key under the **Authentication** section in the Details panel.
 5. If the play mode is not set to **VR Preview**, click on the 3 dots and select **VR Preview**, otherwise just hit play.
 
 
@@ -22,7 +22,7 @@ Allows users to explore a city/map from the first person perspective using Virtu
 5. Using the blueprints Tick Function, create a function that allows the **Follow Camera Blueprint** to follow the Virtual Reality Character. This is used for rendering the **ArcGISMap Component** and any layers you may have added.  
 3. Add the Virtual Reality Character to the level.
    - Mesh colliders need to be enabled in the **ArcGIS Map Component**.
-   - If you want to place the character on a specific location, use the [**ArcGIS Location Component**](https://developers.arcgis.com/unreal-engine/maps/location-component/) to specify its location.
+   - If you want to place the character in a specific location, use the [**ArcGIS Location Component**](https://developers.arcgis.com/unreal-engine/maps/location-component/) to specify its location.
    - Adjust the `Z` Location value of the character to be above the location you would like it at.
 
 ## About the data


### PR DESCRIPTION
- [x] Unifying the title from the github repo readme.md based on the [doc guidelines](https://docs.afd.geocloud.com/doc-authors/)

![image](https://github.com/Esri/arcgis-maps-sdk-unity-samples/assets/106696949/c5824b5a-79f7-460b-9da0-0953ed758a7b)
