### PR TITLE
Bug fixing: measure calculation regression 

### DIFF
--- a/sample_project/Source/sample_project/Measure/Measure.cpp
+++ b/sample_project/Source/sample_project/Measure/Measure.cpp
@@ -42,7 +42,7 @@ void AMeasure::BeginPlay()
 		UE_LOG(LogTemp, Error, TEXT("ArcGISMapActor not found in the level!"));
 	}
 
-	SpatialRef = UArcGISSpatialReference::CreateArcGISSpatialReference(3857);
+	SpatialRef = MapComponent -> GetOriginPosition() -> GetSpatialReference();
 
 	inputManager->OnInputTrigger.AddDynamic(this, &AMeasure::AddStop);
 
@@ -101,14 +101,12 @@ void AMeasure::AddStop()
 
 		auto lineMarker = GetWorld()->SpawnActor<ARouteMarker>(ARouteMarker::StaticClass(), hit.ImpactPoint, FRotator(0), SpawnParam);
 
-		FGeoPosition lineMarkerGeo = MapComponent->EngineToGeographic(lineMarker->GetActorLocation());
-		UArcGISPoint* thisPoint = UArcGISPoint::CreateArcGISPointWithXYZSpatialReference(lineMarkerGeo.X, lineMarkerGeo.Y,lineMarkerGeo.Z, SpatialRef);
+		auto thisPoint = MapComponent->TransformEnginePositionToPoint(hit.ImpactPoint);
 
 		if (!Stops.IsEmpty())
 		{
 			auto lastStop = Stops.Last();
-			FGeoPosition lastStopGeo = MapComponent->EngineToGeographic(lastStop->GetActorLocation());
-			UArcGISPoint* lastPoint = UArcGISPoint::CreateArcGISPointWithXYZSpatialReference(lastStopGeo.X, lastStopGeo.Y, lastStopGeo.Z, SpatialRef);
+			auto lastPoint = MapComponent->TransformEnginePositionToPoint(lastStop->GetActorLocation());
 
 			//Calculate distance from last point to this point
 			SegmentDistance = UArcGISGeometryEngine::DistanceGeodetic(lastPoint, thisPoint, Unit,

--- a/sample_project/Source/sample_project/Measure/Measure.h
+++ b/sample_project/Source/sample_project/Measure/Measure.h
@@ -23,7 +23,6 @@
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
 #include "Materials/MaterialExpressionConstant3Vector.h"
-#include "ArcGISMapsSDK/Utils/GeoCoord/GeoPosition.h"
 #include "ArcGISMapsSDK/API/GameEngine/Geometry/ArcGISGeometry.h"
 #include "ArcGISMapsSDK/Actors/ArcGISMapActor.h"
 #include "ArcGISMapsSDK/BlueprintNodes/GameEngine/Geometry/ArcGISAngularUnit.h"

--- a/sample_project/Source/sample_project/Measure/Measure.h
+++ b/sample_project/Source/sample_project/Measure/Measure.h
@@ -23,7 +23,7 @@
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
 #include "Materials/MaterialExpressionConstant3Vector.h"
-
+#include "ArcGISMapsSDK/Utils/GeoCoord/GeoPosition.h"
 #include "ArcGISMapsSDK/API/GameEngine/Geometry/ArcGISGeometry.h"
 #include "ArcGISMapsSDK/Actors/ArcGISMapActor.h"
 #include "ArcGISMapsSDK/BlueprintNodes/GameEngine/Geometry/ArcGISAngularUnit.h"
@@ -88,6 +88,9 @@ private:
 	TArray<AActor*> FeaturePoints;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta = (AllowPrivateAccess))
 	class AInputManager* inputManager;
+	UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess))
+	AArcGISMapActor* MapActor;
+	UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess))
 	TObjectPtr<UArcGISMapComponent> MapComponent;
 	FVector2D RouteCueScale = FVector2D(5);
 	UStaticMesh* RouteMesh = LoadObject<UStaticMesh>(nullptr, TEXT("/Game/SampleViewer/SharedResources/Geometries/Cube.Cube"));
@@ -106,6 +109,7 @@ private:
 	double SegmentDistance;
 	FActorSpawnParameters SpawnParam = FActorSpawnParameters();
 	float MarkerHeight = 7000.0f;
+	UArcGISSpatialReference* SpatialRef;
 
 	UFUNCTION()
 	void AddStop();


### PR DESCRIPTION
**Sample**

Measure sample used to show the right distance, now it's showing that the golden gate bridge is 7000 miles 

![image](https://github.com/user-attachments/assets/69971218-a734-4088-9e89-38da18859c5d)

This happens for both the bp version and the c++ version. This PR fixes the C++ level, the BP one will be fixed in a separate PR.
Not sure when the plugin code changes that causes this issue. 

In this PR I use `MapComponent->EngineToGeographic` to do the conversion. 


**Checklist**

<!--- Delete any that don't apply -->

- [x] PR title follows convention - `keyword: Short description of change` <!--- Example:  ansible: Update build scripts to handle new engine versions -->
- [x] PR targets the correct branch <!-- Changes going into `main` work with the current public release of the plugin-->
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] No unnecessary includes or namespaces added
- [x] Code follows plugin coding style
- [x] New code and changed code has proper formatting <!-- Run a formatter if unsure -->
- [x] No unintentional formatting changes
- [x] Commits have descriptive titles


**ArcGIS Maps SDK Version**

2.0+unreal 5.5
