### PR TITLE
Bug fix: breadcrumb not having static mesh

### DIFF
--- a/sample_project/Source/sample_project/Routing/Breadcrumb.cpp
+++ b/sample_project/Source/sample_project/Routing/Breadcrumb.cpp
@@ -29,6 +29,13 @@ ABreadcrumb::ABreadcrumb()
 	MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("MarkerMesh"));
 	MeshComponent->SetupAttachment(Root);
 	MeshComponent->SetWorldScale3D(MeshScale);
+
+	static ConstructorHelpers::FObjectFinder<UStaticMesh> MeshAsset(TEXT("/Game/SampleViewer/SharedResources/Geometries/Cube.Cube"));
+	if (MeshAsset.Succeeded())
+	{
+		MeshComponent->SetStaticMesh(MeshAsset.Object);
+	}
+
 	ArcGISLocation = CreateDefaultSubobject<UArcGISLocationComponent>(TEXT("ArcGISLocation"));
 	ArcGISLocation->SetupAttachment(Root);
 }

--- a/sample_project/Source/sample_project/Routing/Breadcrumb.cpp
+++ b/sample_project/Source/sample_project/Routing/Breadcrumb.cpp
@@ -31,6 +31,7 @@ ABreadcrumb::ABreadcrumb()
 	MeshComponent->SetWorldScale3D(MeshScale);
 
 	static ConstructorHelpers::FObjectFinder<UStaticMesh> MeshAsset(TEXT("/Game/SampleViewer/SharedResources/Geometries/Cube.Cube"));
+
 	if (MeshAsset.Succeeded())
 	{
 		MeshComponent->SetStaticMesh(MeshAsset.Object);


### PR DESCRIPTION
**Sample**

Routing and measure sample used to have cube markers. On routing samples, they're used to show route points returned by the routing service; in measure samples, they're used to mark interpolation points. Now they disappear. This is due to Unreal changes. 

Current: 
![image](https://github.com/user-attachments/assets/b25f75d3-44a6-4b26-a2f4-03fbe4fe7620)

After fix:
![current](https://github.com/user-attachments/assets/2f2c7009-9d58-48b9-91e8-10ed2540fe04)


**Checklist**

<!--- Delete any that don't apply -->

- [x] PR title follows convention - `keyword: Short description of change` <!--- Example:  ansible: Update build scripts to handle new engine versions -->
- [x] PR targets the correct branch <!-- Changes going into `main` work with the current public release of the plugin-->
- [ ] New Blueprints follow Unreal Naming Convention <!-- bp_BlueprintFileName, wbp_WidgetFileName, e_EnumFileName, animbp_AnimationBlueprintFileName, etc -->
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [ ] A build was made and tested on all relevant platforms
- [x] No unrelated changes have been made to any other code or project files
- [x] No unnecessary includes or namespaces added
- [x] Code follows plugin coding style
- [x] New code and changed code has proper formatting <!-- Run a formatter if unsure -->
- [x] No unintentional formatting changes
- [x] Commits have descriptive titles

**Blueprints**
<!--- Please list any blueprint files that were changed and should be code reviewed -->

**ArcGIS Maps SDK Version**

<!-- Mention what version of the Maps SDK was used to test/develop this code -->
