### PR TITLE
5.7 Support: Fix user widget include

### DIFF
--- a/sample_project/Source/sample_project/OverviewMap/OverviewMapCamera.h
+++ b/sample_project/Source/sample_project/OverviewMap/OverviewMapCamera.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "Blueprint/UserWidget.h"
 #include "CoreMinimal.h"
 #include "Engine/TextureRenderTarget2D.h"
 #include "GameFramework/Actor.h"


### PR DESCRIPTION
**Summary**

The Overview Map sample does not compile in 5.7, this include resolves that. Also tested in 5.3.